### PR TITLE
Add norikra-client.rb

### DIFF
--- a/lib/norikra-client.rb
+++ b/lib/norikra-client.rb
@@ -1,0 +1,1 @@
+require 'norikra/client'


### PR DESCRIPTION
README.md says `require 'norikra-client'`, but

```
[1] pry(main)> require 'norikra-client'
LoadError: cannot load such file -- norikra-client
from /Users/yuki_ito/.rbenv/versions/2.0.0-p0/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
```
